### PR TITLE
remove colon from downloaded filename 

### DIFF
--- a/garmin.py
+++ b/garmin.py
@@ -150,8 +150,9 @@ class Garmin(EasyAnt):
         (fno, ftype, flags, size, date_mod) = filedat
         self._logger.debug("got %s, want %s", totsize, size)
         
+        file_date_time = date_mod.strftime("%Y-%m-%d_%H-%M-%S")
         
-        filename = str.format("{}-{:02x}-{}-{}-{}.fit", fno, ftype, date_mod.isoformat("_"), size, totsize)
+        filename = str.format("{}-{:02x}-{}-{}-{}.fit", fno, ftype, file_date_time, size, totsize)
         with open(filename, "w") as f:
             filecontent.tofile(f)
         print "Done downloading", filename


### PR DESCRIPTION
Of course you can worked around this but having no colons in the filname can ease processing of the file on the commandline.
Basically this is not a bug but rather my personal preference ... so you can very well ignore this "feature".

Andreas
