### PR TITLE
 Added line numbers to the log format and right aligned the 'name' variable.

### DIFF
--- a/garmin.py
+++ b/garmin.py
@@ -313,14 +313,10 @@ def main():
     handler = logging.FileHandler(currentTime + "-garmin.log", "w")
     #handler = logging.StreamHandler()
 
-    # New log format which adds linenumber.
-    # If you add new module/logger names longer than the 15 characters just increase the value after %(name).
+    # If you add new module/logger name longer than the 15 characters just increase the value after %(name).
     # The longest module/logger name now is "garmin.ant.base" and "garmin.ant.easy".
-    # handler.setFormatter(logging.Formatter(fmt='%(asctime)s  %(name)15s:%(lineno)-4d  %(levelname)-8s  %(message)s'))
     handler.setFormatter(logging.Formatter(fmt='%(asctime)s  %(name)-15s  %(levelname)-8s  %(message)s (%(filename)s:%(lineno)d)'))
 
-    # Previous log format. Keep this for awhile until we are satisfied with the new one. 
-    #handler.setFormatter(logging.Formatter(fmt='%(asctime)s  %(name)-15s  %(levelname)-8s  %(message)s'))
     logger.addHandler(handler)
 
     g = Garmin()


### PR DESCRIPTION
#### Old log format

```
2012-08-15 17:05:25,778  garmin.ant.base  DEBUG     USB Find device, vendor 0xfcf, product 0x1008
2012-08-15 17:05:25,797  garmin.ant.base  DEBUG     USB Config values:
2012-08-15 17:05:25,797  garmin.ant.base  DEBUG      Config 1
2012-08-15 17:05:25,797  garmin.ant.base  DEBUG       Interface 0, Alt 0
2012-08-15 17:05:25,797  garmin.ant.base  DEBUG        Endpoint 129
2012-08-15 17:05:25,797  garmin.ant.base  DEBUG        Endpoint 1
2012-08-15 17:05:25,798  garmin.ant.base  DEBUG     No kernel driver active
2012-08-15 17:05:25,965  garmin.ant.base  DEBUG     UBS Endpoint out: <usb.core.Endpoint object at 0x16fb890>, 1
2012-08-15 17:05:25,966  garmin.ant.base  DEBUG     UBS Endpoint in: <usb.core.Endpoint object at 0x16fb850>, 129
2012-08-15 17:05:25,966  garmin.ant.base  DEBUG     Ant runner started
2012-08-15 17:05:25,966  garmin           DEBUG     Creating directories
```
#### New log format

```
2012-08-15 18:52:01,649  garmin.ant.base:184   DEBUG     USB Find device, vendor 0xfcf, product 0x1008
2012-08-15 18:52:01,669  garmin.ant.base:191   DEBUG     USB Config values:
2012-08-15 18:52:01,669  garmin.ant.base:193   DEBUG      Config 1
2012-08-15 18:52:01,670  garmin.ant.base:195   DEBUG       Interface 0, Alt 0
2012-08-15 18:52:01,670  garmin.ant.base:197   DEBUG        Endpoint 129
2012-08-15 18:52:01,670  garmin.ant.base:197   DEBUG        Endpoint 1
2012-08-15 18:52:01,670  garmin.ant.base:204   DEBUG     No kernel driver active
2012-08-15 18:52:01,842  garmin.ant.base:230   DEBUG     UBS Endpoint out: <usb.core.Endpoint object at 0x2739890>, 1
2012-08-15 18:52:01,842  garmin.ant.base:241   DEBUG     UBS Endpoint in: <usb.core.Endpoint object at 0x2739850>, 129
2012-08-15 18:52:01,843  garmin.ant.base:287   DEBUG     Ant runner started
2012-08-15 18:52:01,843           garmin:72    DEBUG     Creating directories
```

I just wanted line numbers. I tested with filename instead but I think the module name (same as logger name) makes more sense when you start to understand the code.
