### PR TITLE
Added an INFO log level message for each print out in the terminal.

### DIFF
--- a/garmin.py
+++ b/garmin.py
@@ -44,6 +44,17 @@ PRODUCT_NAME = "garmin-extractor"
 
 _logger = logging.getLogger("garmin")
 
+# This class filters logging to console
+# to only show INFO level messages
+# http://stackoverflow.com/questions/8162419/python-logging-specific-level-only/8163115#8163115
+class OnlyLogLevel(object):
+    def __init__(self, level):
+        self.__level = level
+
+    def filter(self, logRecord):
+        return logRecord.levelno <= self.__level
+
+# Main class
 class Garmin(EasyAnt):
 
     class State:
@@ -344,7 +355,8 @@ def main():
     # Setting up the console messages (or console "logging") 
     console = logging.StreamHandler()
     console.setLevel(logging.INFO)
-    console.setFormatter(logging.Formatter(fmt='%(levelname)-8s %(message)s'))
+    console.addFilter(OnlyLogLevel(logging.INFO))
+    console.setFormatter(logging.Formatter(fmt='%(message)s'))
     logger.addHandler(console)
 
     g = Garmin()
@@ -352,3 +364,4 @@ def main():
 
 if __name__ == "__main__":
     sys.exit(main())
+


### PR DESCRIPTION
(This pull request includes the changes from pull request #28 as well so it might be better to start with that pull request to master)

When trying to follow the DEBUG messsages I had a hard time finding out exactly when the index was being downloaded, when each file was being downloaded and when each file download finished. This information was printed out to the terminal but nothing about it in the log file.

Therefore, for each print out to the terminal I added and message to the logger on log level INFO. If you now filter out your garmin.log file for all rows with "INFO" you will get the same printout that the user gets in the terminal. It's now much easier to follow the log files, at least that is what I think. =)
##### The drawback

The drawback of this is that the code in "garmin.py" is a little bit harder to follow now with all the _logger.info() additions. This is a trade off I'm ready to accept.
