### PR TITLE
typo in USB3 Driver definition

### DIFF
--- a/ant/base/driver.py
+++ b/ant/base/driver.py
@@ -226,7 +226,7 @@ try:
 
     class USB3Driver(USBDriver):
         ID_VENDOR  = 0x0fcf
-        ID_PRODUCT = 0x1008
+        ID_PRODUCT = 0x1009
 
     drivers.append(USB2Driver)
     drivers.append(USB3Driver)


### PR DESCRIPTION
Sorry about the previous, online editing failed me. This PR fixes an important typo in the new USB3 code.
