### PR TITLE
Document that we need Python 2.7+

### DIFF
--- a/README
+++ b/README
@@ -1,6 +1,8 @@
 Requirements
 ==============================================================================
 
+- Python 2.7+
+
 - PyUSB 1.0 (seems to be a bug which makes it segfaults on version before
   Alpha 2). It is recommended to use pip to install PyUSB:
   


### PR DESCRIPTION
At least for collections.OrderedDict(). Debian stable is 2.7, so
doesn't seem worth trying to use some shim.

Signed-off-by: Chris Lamb lamby@debian.org
