### PR TITLE
Added row to the README about reboot for the udev rules to apply.

### DIFF
--- a/README
+++ b/README
@@ -5,7 +5,7 @@ Requirements
 
 - PyUSB 1.0 (seems to be a bug which makes it segfaults on version before
   Alpha 2). It is recommended to use pip to install PyUSB:
-  
+
   pip install pyusb
 
   Alternatively you can install it from GitHub:
@@ -16,6 +16,8 @@ Requirements
   running the program as root. Install with:
 
   sudo cp resources/ant-usbstick2.rules /etc/udev/rules.d
+
+  and then reboot your system for the rules to apply.
 
 Supported devices
 ==============================================================================


### PR DESCRIPTION
I just tried the installation instructions on xubuntu 14.04 Trusty Tahr and it required me to reboot my system for the udev rules to apply. I tried to reload the rules with udevadm but they didn't take affect, the command I used was:

```
sudo udevadm control --reload-rules
```
