### PR TITLE
Download steps data from devices

### DIFF
--- a/antfs-cli.py
+++ b/antfs-cli.py
@@ -55,7 +55,8 @@ _directories = {
     "sports":     File.Identifier.SPORT_SETTING,
     "totals":     File.Identifier.TOTALS,
     "weight":     File.Identifier.WEIGHT,
-    "workouts":   File.Identifier.WORKOUT}
+    "workouts":   File.Identifier.WORKOUT,
+    "steps":      File.Identifier.STEPS}
 
 _filetypes = dict((v, k) for (k, v) in _directories.items())
 


### PR DESCRIPTION
Needs to [add the identifier first ](https://github.com/Tigge/openant/pull/2).

Not sure if it's only steps data or every data on a vivofit device (including activities and sleep). In the second case the identifier should probably be renamed.
Other users of the vivofit, feedback is appreciated ( @shookees ?)

Thanks
