### PR TITLE
Fix division by zero error in progress callback when uploading

### DIFF
--- a/garmin.py
+++ b/garmin.py
@@ -275,7 +275,10 @@ class Garmin(Application):
     def _get_progress_callback(self):
         def callback(new_progress):
             delta = time.time() - callback.start_time
-            eta = datetime.timedelta(seconds=int(delta / new_progress - delta))
+            if new_progress != 0.0:
+                eta = datetime.timedelta(seconds=int(delta / new_progress - delta))
+            else:
+                eta = "Unknown"
             s = "[{0:<30}] ETA: {1}".format("." * int(new_progress * 30), eta)
             sys.stdout.write(s)
             sys.stdout.flush()


### PR DESCRIPTION
Fix bug uploading where first call to the progress callback occurs with a 0.0 value for the new_progress argument resulting in a division by zero error.

When the progress percentage is exactly zero, it is not possible to guess how much time remains based on the elapsed time. So it makes sense to instead display "ETA: Unknown".
