### PR TITLE
Only output message about uploading if we are uploading files

### DIFF
--- a/antfs-cli.py
+++ b/antfs-cli.py
@@ -228,8 +228,9 @@ class AntFSCLI(Application):
                     local_files[filetype])
             upload_total += len(uploading[filetype])
 
-        print "Downloading", download_total, "file(s)", \
-              "and uploading", upload_total, "file(s)"
+        print "Downloading", download_total, "file(s)"
+        if self.uploading:
+              print " and uploading", upload_total, "file(s)"
 
         # Download missing files:
         for files in downloading.values():


### PR DESCRIPTION
This is the same fix as #107, but on top of the split branch.

_Caveat_: I've not actually managed to run `python antfs-cli.py` due to a missing constant by the looks of it:

```
$ python antfs-cli.py
Traceback (most recent call last):
  File "antfs-cli.py", line 50, in <module>
    "monitoring_b": File.Identifier.MONITORING_B,
AttributeError: class Identifier has no attribute 'MONITORING_B'
```
