### PR TITLE
Fix pylint warning: super-init-not-called

### DIFF
--- a/antfs_cli/utilities.py
+++ b/antfs_cli/utilities.py
@@ -38,7 +38,7 @@ def makedirs_if_not_exists(path):
 
 class XDGError(Exception):
     def __init__(self, message):
-        self.message = message
+        super(XDGError, self).__init__(message)
 
 
 class XDG:


### PR DESCRIPTION
```
************* Module antfs_cli.utilities
W: 40, 4: __init__ method from base class 'Exception' is not called (super-init-not-called)

Global evaluation
-----------------
Your code has been rated at 6.77/10 (previous run: 6.72/10, +0.05)
```