### PR TITLE
Use garmin-uploader in upload script

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,27 @@ Usage
       --upload    enable uploading
       --debug     enable debug
 
+Upload to Garmin Connect
+------------------------
+
+This program can upload automatically the activities from your watch to [Garmin Connect](https://connect.garmin.com) by using [garmin-uploader](https://github.com/La0/garmin-uploader).
+
+To setup the activity upload, follow these steps:
+
+ 1. Install upload extra dependecies
+    ```
+    sudo pip install antfs-cli[upload]
+    ```
+ 2. Setup your Garmin Connect credentials in `~/.guploadrc`
+    ```
+    [Credentials]
+    username=yourgarminuser
+    password=yourgarminpass
+    ```
+ 3. Copy the file `scripts/40-upload_to_garmin_connect.py` into the directory `~/.config/antfs-cli/scripts`
+    Make sure it is still executable.
+
+Now after every successful activity download from your watch, the activity will be uploaded to Garmin Connect.
 
 File locations
 --------------

--- a/scripts/40-upload_to_garmin_connect.py
+++ b/scripts/40-upload_to_garmin_connect.py
@@ -1,21 +1,19 @@
 #!/usr/bin/python
 #
-# Code by Tony Bussieres <t.bussieres@gmail.com> inspired by 
-# 40-convert_to_tcx.py by Gustav Tiger <gustav@tiger.name>
+# Code by Tony Bussieres <t.bussieres@gmail.com>
+# Updated by Bastien Abadie <bastien@nextcairn.com>
+# inspired by 40-convert_to_tcx.py by Gustav Tiger <gustav@tiger.name>
 #
-# This helper uses GcpUploader to send the fit files to Garmin Connect
-# 
-# To install GcpUploader:
+# This helper uses garmin-uploader to send the fit files to Garmin Connect
 #
-# sudo pip install GcpUploader
+# To install garmin-uploader
+#
+# sudo pip install garmin-uploader
 #
 # edit the file ~/.guploadrc and add the following
 # [Credentials]
 # username=yourgarminuser
 # password=yourgarminpass
-#
-# Then point the GUPLOAD environment variable at the path to your gupload.py
-# script (defaults to /usr/bin/gupload.py)
 #
 # Don't forget to make this script executable :
 #
@@ -23,48 +21,40 @@
 
 from __future__ import absolute_import, print_function
 
-import errno
-import os
-import subprocess
 import sys
+import os.path
+import logging
 
-gupload = os.getenv("GUPLOAD") or "/usr/bin/gupload.py"
-if not os.path.exists(gupload):
-    sys.stderr.write("%s didn't exist; ensure GcpUploader is installed, "
-                     "and set GUPLOAD correctly if necessary.\n")
+try:
+    from garmin_uploader import logger
+    from garmin_uploader.user import User
+    from garmin_uploader.workflow import Activity
+except ImportError:
+    print('Python package garmin_uploader is not available. Please install with pip install garmin-uploader')
     sys.exit(1)
 
+# Setup garmin uploader logger
+logger.setLevel(logging.INFO)
+
 def main(action, filename):
+    assert os.path.exists(filename)
 
     if action != "DOWNLOAD":
         return 0
 
-    try:
-        process = subprocess.Popen([gupload, filename], stdout=subprocess.PIPE,
-                                   stderr=subprocess.PIPE)
-        (data, _) = process.communicate()
-    except OSError as e:
-        print("Could not send to Garmin", gupload, \
-              "-", errno.errorcode[e.errno], os.strerror(e.errno))
+    # Auth with ~/.guploadrc credentials
+    user = User()
+    if not user.authenticate():
+        logger.error('Invalid Garmin Connect credentials')
         return -1
 
-    if process.returncode != 0:
-        print("gupload.py exited with error code", process.returncode)
+    # Upload the activity
+    activity = Activity(filename)
+    if not activity.upload(user):
+        logger.error('Failed to send activity to Garmin')
         return -1
 
-    if data.find("Status: SUCCESS ") != -1:
-        print("Successfully uploaded %s to Garmin Connect" % filename)
-        return 0
-
-    if data.find("Status: EXISTS ") != -1:
-        print("%s already uploaded to Garmin Connect" % filename)
-        return 0
-
-    print("Couldn't understand output from uploading %s to Garmin Connect:" %
-          filename)
-    print(data)
-    return -1
+    return 0
 
 if __name__ == "__main__":
     sys.exit(main(sys.argv[1], sys.argv[2]))
-

--- a/setup.py
+++ b/setup.py
@@ -58,7 +58,10 @@ setup(name='antfs-cli',
                    'Programming Language :: Python :: 3.4',
                    'Programming Language :: Python :: 3.5'],
 
-      dependency_links=['git+https://github.com/Tigge/openant.git#egg=openant-0.3'], 
+      dependency_links=['git+https://github.com/Tigge/openant.git#egg=openant-0.3'],
       install_requires=['openant>=0.3'],
+      extras_require={
+          'upload': ['garmin-uploader'],
+      },
 
       test_suite='tests')


### PR DESCRIPTION
This Pull Request enables the usage of garmin-uploader instead of GCPUploader in the script `40-upload_to_garmin_connect.py `.
I also added garmin-uploader as an extra depency in `setup.py`, so a user can install antfs-cli + garmin-uploader in a single command :

```
sudo pip install antfs-cli[upload]
```