### PR TITLE
Fixed python shebang

### DIFF
--- a/antfs_cli/program.py
+++ b/antfs_cli/program.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 #
 # Ant
 #

--- a/scripts/40-convert_to_tcx.py
+++ b/scripts/40-convert_to_tcx.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 #
 # Script to run the FIT-to-TCX converter on every new FIT file that is being
 # downloaded by antfs-cli. Installation of https://github.com/Tigge/FIT-to-TCX

--- a/scripts/40-upload_to_garmin_connect.py
+++ b/scripts/40-upload_to_garmin_connect.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 #
 # Code by Tony Bussieres <t.bussieres@gmail.com>
 # Updated by Bastien Abadie <bastien@nextcairn.com>


### PR DESCRIPTION
The shebang in the fixed files was `/usr/bin/python`, thus hard-coding
the python interpreter that would be used. Fixed to the general
`/usr/bin/env python`, that picks the interpreter base on the environment.