### PR TITLE
Add support for uploading files to Strava

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,23 @@ To setup the activity upload, follow these steps:
 
 Now after every successful activity download from your watch, the activity will be uploaded to Garmin Connect.
 
+Upload to Strava
+------------------------
+This program can upload automatically the activities from your watch to [Strava](https://strava.com) by using [stravalib](https://github.com/hozn/stravalib) and [drpexe-uploader](https://github.com/mscansian/drpexe-uploader).
+
+To setup the activity upload, follow these steps:
+
+ 1. Install upload extra dependecies
+    ```
+    sudo pip install stravalib
+    ```
+ 2. Run the script `scripts/40-upload_to_strava.py` to fetch your Strava credentials. Follow the instructions to authorize [drpexe-uploader](https://github.com/mscansian/drpexe-uploader) to upload files on your behalf.
+    ```
+    ./scripts/40-upload_to_strava.py
+    ```
+ 3. Copy the file `scripts/40-upload_to_strava.py` into the directory `~/.config/antfs-cli/scripts`
+    Make sure it is still executable.
+
 File locations
 --------------
 

--- a/scripts/40-upload_to_strava.py
+++ b/scripts/40-upload_to_strava.py
@@ -1,0 +1,131 @@
+#!/usr/bin/env python3
+#
+# Code by Matheus Cansian <dev@drpexe.com>
+#
+# This helper uses stravalib to send the fit files to Strava
+#
+# To install stravalib
+#
+# sudo pip install stravalib
+#
+# This script uses a third party API to facilitate Strava's OAuth
+# authentication. If you want to deploy your own API you can use
+# the instructions below and change the constants on this script.
+# https://github.com/mscansian/drpexe-uploader
+#
+# You can fetch the credentials by running the script without any arguments
+#
+# ./40-upload_to_strava.py
+#
+# Credentials are written to ~/.drpexe-uploader-credentials
+#
+# Don't forget to make this script executable :
+#
+# chmod +x /path/to/40-upload_to_strava.py
+from __future__ import print_function, with_statement
+
+import sys
+import os.path
+
+try:
+    from urllib.parse import urlparse
+    from http.server import HTTPServer, BaseHTTPRequestHandler
+except ImportError:  # Python 2.7
+    from urlparse import urlparse
+    from BaseHTTPServer import HTTPServer, BaseHTTPRequestHandler
+
+from stravalib import Client
+from stravalib.exc import ActivityUploadFailed
+
+# drpexe-uploader config
+# https://github.com/mscansian/drpexe-uploader
+# do not change unless you want to create your own strava app
+DRPEXE_CLIENT_ID = 17666
+DRPEXE_UPLOADER_API = (
+    'https://in27m0omnk.execute-api.us-east-1.amazonaws.com/prod'
+)
+
+STRAVA_CREDENTIALS_FILE = os.path.expanduser('~/.drpexe-uploader-credentials')
+STRAVA_UPLOAD_PRIVATE = False
+LOCAL_SERVER_PORT = 8000
+
+
+def main(action, filename):
+    if action != "DOWNLOAD":
+        return 0
+
+    try:
+        with open(STRAVA_CREDENTIALS_FILE, 'r') as f:
+            access_token = f.read().strip(' \t\n\r')
+    except FileNotFoundError:
+        print('No Strava credentials provided.')
+        print('You first need to run the script to fetch the credentials')
+        print('./40-upload_to_strava.py')
+        return -1
+
+    try:
+        client = Client(access_token=access_token)
+        print('Uploading {}: '.format(os.path.basename(filename)), end='')
+        with open(filename, 'rb') as f:
+            upload = client.upload_activity(
+                activity_file=f,
+                data_type='fit',
+                private=STRAVA_UPLOAD_PRIVATE,
+            )
+    except (ActivityUploadFailed, FileNotFoundError) as err:
+        print('FAILED')
+        print('Reason:', err)
+        return -1
+
+    print('SUCCESS')
+    return 0
+
+
+def start_strava_auth_flow():
+    print('---------------------------------------------')
+    print('| Starting Strava OAuth authentication flow |')
+    print('---------------------------------------------\n')
+
+    client = Client()
+    url = client.authorization_url(
+        client_id=DRPEXE_CLIENT_ID,
+        redirect_uri=DRPEXE_UPLOADER_API,
+        scope='write',
+        state='REDIRECT-%s' % LOCAL_SERVER_PORT,
+    )
+    print('Open the following page to authorize drpexe-uploader to '
+          'upload files to your Strava account\n')
+    print(url)
+
+    httpd = HTTPServer(('127.0.0.1', LOCAL_SERVER_PORT), AuthRequestHandler)
+    httpd.handle_request()
+
+
+class AuthRequestHandler(BaseHTTPRequestHandler):
+    def do_GET(self):
+        querystring = urlparse(self.path).query
+        key, value = querystring.split('=')
+        assert key == 'access_token'
+
+        # Write credentials to disk
+        with open(STRAVA_CREDENTIALS_FILE, 'w') as f:
+            f.write(value)
+
+        self.send_response(200)
+        self.send_header('Content-type', 'text/html')
+        self.end_headers()
+        self.wfile.write(
+            (
+                'This message means you have been successfully authenticated.'
+                '\n\nYou can now close this page.'
+            ).encode("utf-8")
+        )
+        print('Authentication succeeded')
+        print('Credentials have been saved to %s' % STRAVA_CREDENTIALS_FILE)
+
+
+if __name__ == "__main__":
+    if len(sys.argv) != 1:
+        sys.exit(main(action=sys.argv[1], filename=sys.argv[2]))
+    start_strava_auth_flow()
+    sys.exit(0)


### PR DESCRIPTION
This PR enables an user to upload files directly to Strava. It uses [stravalib](https://github.com/hozn/stravalib) to handle the API calls.

Since Strava uses 3-legged OAuth protocol for authentication, I've had to create an app in Strava and an API to sit in the middle of the authentication. This API is open-source and [available here](https://github.com/mscansian/drpexe-uploader).

I've also took the liberty of deploying the API to Amazon Web Services using AWS API Gateway and Lambda. This configuration is serverless and requires no maintenance on my part, this means that will stay up for the foreseeable future. My API endpoint and Strava's app id are hardcoded into the script.

## Additional details
I made a decision to create a third party API in the middle of the authentication to ease the setup for the user. Had I not done so, it would mean that every user need to create an app in Strava and configure the client id and client secret. I've used software that works this way and have not enjoyed it.

If for some reason a user don't trust/want to use my API, he can also use the [code published](https://github.com/mscansian/drpexe-uploader) to deploy his own.

**IMPORTANT: This script requires Python 3.** For some reason my dependencies are not working on Python 2.7. I've configured the script to run using python3 for the time being. As soon as the problems are fixed ([here](https://github.com/crsmithdev/arrow/issues/537) and [here](https://github.com/hozn/stravalib/issues/149)), it can be changed back to system python.

## Related issues
 #171 