### PR TITLE
scripts: Update Strava OAuth scopes to match stravalib master

### DIFF
--- a/scripts/40-upload_to_strava.py
+++ b/scripts/40-upload_to_strava.py
@@ -90,7 +90,7 @@ def start_strava_auth_flow():
     url = client.authorization_url(
         client_id=DRPEXE_CLIENT_ID,
         redirect_uri=DRPEXE_UPLOADER_API,
-        scope='write',
+        scope='activity:write',
         state='REDIRECT-%s' % LOCAL_SERVER_PORT,
     )
     print('Open the following page to authorize drpexe-uploader to '


### PR DESCRIPTION
Strava has recently expanded its permissions model, meaning more
detailed scopes. The old ‘write’ scope is no longer accepted.

See https://github.com/hozn/stravalib/issues/168.

Signed-off-by: Philip Withnall <philip@tecnocode.co.uk>