### PR TITLE
scripts: Use local server for Strava auth

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: python
 python:
   - 2.7
-  - 3.3
   - 3.4
   - 3.5
   - 3.6

--- a/scripts/40-upload_to_strava.py
+++ b/scripts/40-upload_to_strava.py
@@ -26,6 +26,7 @@ from __future__ import print_function, with_statement
 
 import pickle
 import sys
+import time
 import os.path
 import xdg.BaseDirectory
 
@@ -57,6 +58,16 @@ def main(action, filename):
         with open(STRAVA_CREDENTIALS_FILE, 'rb') as f:
             token_data = pickle.load(f)
             access_token = token_data['access_token']
+
+            if token_data['expires_at'] <= time.time():
+                client = Client()
+                token_data = client.refresh_access_token(client_id=CLIENT_ID,
+                                                         client_secret=CLIENT_SECRET,
+                                                         refresh_token=token_data['refresh_token'])
+                access_token = token_data['access_token']
+
+                with open(STRAVA_CREDENTIALS_FILE, 'wb') as fw:
+                    pickle.dump(token_data, fw, 0)
     except (FileNotFoundError, KeyError):
         print('No Strava credentials provided.')
         print('You first need to run the script to fetch the credentials')


### PR DESCRIPTION
Several changes combined into one:
 • Redirect back to the local server to complete the auth flow, rather
   than pointlessly redirecting via an AWS server
 • Convert the temporary token into a long-term token so that people
   don’t have to reauthenticate every time they want to upload an
   activity
 • Don’t use a fixed local port — allow the OS to allocate us one
 • Store the access and refresh tokens in the correct directory
   according to the XDG Base Directory specification
   (https://standards.freedesktop.org/basedir-spec/basedir-spec-latest.html)

I’ve registered a new application with Strava for doing the
authentication, since the client secret is needed.

Signed-off-by: Philip Withnall <philip@tecnocode.co.uk>